### PR TITLE
Avoid building Tracy if it is disabled

### DIFF
--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 pub const options = @import("tracy-options");
-const c = @cImport({
+const c = if (options.tracy_enable) @cImport({
     if (options.tracy_enable) @cDefine("TRACY_ENABLE", {});
     if (options.tracy_on_demand) @cDefine("TRACY_ON_DEMAND", {});
     if (options.tracy_callstack) |depth| @cDefine(std.fmt.comptimePrint("TRACY_CALLSTACK \"{d}\"", .{depth}), {});
@@ -26,7 +26,7 @@ const c = @cImport({
     if (options.shared and builtin.os.tag == .windows) @cDefine("TRACY_IMPORTS", {});
 
     @cInclude("tracy/TracyC.h");
-});
+}) else void;
 
 pub inline fn setThreadName(name: [:0]const u8) void {
     if (!options.tracy_enable) return;


### PR DESCRIPTION
# The Issue
If `tracy_enable` is false, the build system still ends up building tracy (just with the `TRACY_ENABLE` macro not set).

Some platforms do not support Tracy (Emscripten, for example), so the logical solution would be to set `tracy_enable` to `false` on those platforms:
```zig
const profile = b.option(bool, //...
const emscripten = b.option(bool, // ...

// <snip>

const tracy_dep = b.dependency("tracy", .{
    .target = target,
    .optimize = optimize,
    .tracy_enable = profile and !emscripten,
});
```

However, in the current version, this still ends up building Tracy, which results in a compile error due to missing headers:
```
C:\Users\Martin\AppData\Local\zig\p\N-V-__8AAMeOlQEipHjcyu0TCftdAi9AQe7EXUDJOoVe0k-t\public/common/TracySystem.cpp:15:12: error: 'pthread.h' file not found
#  include <pthread.h>
           ^~~~~~~~~~~~
C:\Users\Martin\AppData\Local\zig\p\N-V-__8AAMeOlQEipHjcyu0TCftdAi9AQe7EXUDJOoVe0k-t\public\TracyClient.cpp:14:10: note: in file included from C:\Users\Martin\AppData\Local\zig\p\N-V-__8AAMeOlQEipHjcyu0TCftdAi9AQe7EXUDJOoVe0k-t\public\TracyClient.cpp:14:
#include "common/TracySystem.cpp"
```

# The Fix
This PR does the following:
1. Completely disable building the `tracy` artifact when `tracy_enable` is `false`.
2. Avoid doing `@cImport` when `tracy_enable` is `false`.